### PR TITLE
Fixed pandas warning.

### DIFF
--- a/trackanimation/tracking.py
+++ b/trackanimation/tracking.py
@@ -459,7 +459,7 @@ class DFTrack:
 
 			df_concat.append(df.df) 
 
-		return self.__class__(pd.concat(df_concat))
+		return self.__class__(pd.concat(df_concat, sort=True))
 
 
 class ReadTrack:


### PR DESCRIPTION
Every time I run the script, using pandas 0.23.4, I got this warning:

```
/usr/local/lib/python3.7/site-packages/trackanimation/tracking.py:462: FutureWarning: Sorting because non-concatenation axis is not aligned. A future version
of pandas will change to not sort by default.

To accept the future behavior, pass 'sort=False'.

To retain the current behavior and silence the warning, pass 'sort=True'.

  return self.__class__(pd.concat(df_concat))
```

This PR simply does what this error asks to shut up the warning.