### PR TITLE
Fixes HTTP 403 error by bumping smopy-version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ matplotlib>=2.2.3
 mplleaflet==0.0.5
 pandas>=0.23.4
 tqdm>=4.25.0
-smopy==0.0.6
+smopy==0.0.7


### PR DESCRIPTION
See https://github.com/rossant/smopy/issues/16